### PR TITLE
Scroll to top after completing refresh, to avoid some cases when content is stuck

### DIFF
--- a/Sources/Refresher/Refresher.swift
+++ b/Sources/Refresher/Refresher.swift
@@ -259,6 +259,7 @@ public struct RefreshableScrollView<Content: View, RefreshView: View>: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + config.cooldown) {
                         self.canRefresh = true
                         self.isRefresherVisible = false
+						self.uiScrollView?.setContentOffset(.zero, animated: true)
                     }
                 }
             }

--- a/Sources/Refresher/Refresher.swift
+++ b/Sources/Refresher/Refresher.swift
@@ -259,7 +259,7 @@ public struct RefreshableScrollView<Content: View, RefreshView: View>: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + config.cooldown) {
                         self.canRefresh = true
                         self.isRefresherVisible = false
-						self.uiScrollView?.setContentOffset(.zero, animated: true)
+						self.uiScrollView?.setContentOffset(CGPoint(x: 0, y: -headerInset), animated: true)
                     }
                 }
             }


### PR DESCRIPTION
In some cases the content is stuck after refreshing (I don't really understand why).
To add a safeguard I scroll the content scrollView to zero after completing refresh.