### PR TITLE
Fix jittery views when Lazy-loaded content is present in iOS 17

### DIFF
--- a/Examples/ContentView.swift
+++ b/Examples/ContentView.swift
@@ -84,6 +84,8 @@ struct DetailsView: View {
     @State var refreshed = 0
     var style: Style
     @State var useImage = true
+    let rectangles = (0..<50).map { _ in CGFloat.random(in: 10..<50) }
+
     var body: some View {
         ScrollView {
             VStack {
@@ -94,6 +96,25 @@ struct DetailsView: View {
                 }
                 Text("Details!")
                 Text("Refreshed: \(refreshed)")
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: 8) {
+                        ForEach(0..<10) { _ in
+                            Rectangle()
+                                .frame(width: 100, height: 100)
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)) {
+                    ForEach(rectangles, id: \.self) { size in
+                        VStack {
+                            Rectangle()
+                                .frame(width: size, height: size)
+                            Text("text")
+                        }
+                    }
+                }
             }
         }
         .refresher(style: style) {

--- a/Sources/Refresher/OffsetReader.swift
+++ b/Sources/Refresher/OffsetReader.swift
@@ -3,19 +3,23 @@ import SwiftUI
 
 struct OffsetReader: View {
     var onChange: (CGFloat) -> ()
-    @State private var frame = CGRect()
 
     public var body: some View {
         GeometryReader { geometry in
-            Spacer(minLength: 0)
-                .onChange(of: geometry.frame(in: .global)) { value in
-                    if value.integral != self.frame.integral {
-                        DispatchQueue.main.async {
-                            self.frame = value
-                            onChange(value.minY)
-                        }
-                    }
+            Color.clear
+                .preference(key: OffsetPreferenceKey.self,
+                            value: geometry.frame(in: .global).minY)
+                .onPreferenceChange(OffsetPreferenceKey.self) { offset in
+                    onChange(offset)
                 }
         }
+    }
+}
+
+private struct OffsetPreferenceKey: PreferenceKey {
+    static var defaultValue = CGFloat.zero
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }


### PR DESCRIPTION
I encountered an issue in my app where, on iOS 17 and later, if a ScrollView contains LazyViews and the user performs a PullToRefresh, the view becomes jittery.
I attempted to record it, but it's hard to observe, so I would be grateful if you could build the sample with the additional [commit](https://github.com/gh123man/SwiftUI-Refresher/commit/56e4a1c5df3d55c1a0a2e98b5744507ca0b8aec0) on your local machine for more details. In the app I'm developing, due to different conditions, the screen jitter is more pronounced than in the provided sample.

After investigating, it seems that the issue lies with the `DispatchQueue.main.async` when monitoring the offset. However, directly notifying causes SwiftUI to output a warning, so we have opted to use `onPreferenceChange` instead.